### PR TITLE
Display only what's relevant

### DIFF
--- a/filter-out-sandbox-mounts.patch
+++ b/filter-out-sandbox-mounts.patch
@@ -1,0 +1,22 @@
+diff --git a/src/summaryWidget.cpp b/src/summaryWidget.cpp
+index 6c035a2..15b77d6 100644
+--- a/src/summaryWidget.cpp
++++ b/src/summaryWidget.cpp
+@@ -155,6 +155,17 @@ DiskList::DiskList()
+             continue;
+         }
+ 
++        // https://docs.flatpak.org/en/latest/sandbox-permissions.html
++        // /var and friends are not useful paths. /var has some stuff mounted that isn't useful either
++        static const bool inSandbox =
++            !(QStandardPaths::locate(QStandardPaths::RuntimeLocation, QLatin1String("flatpak-info")).isEmpty() ||
++              qEnvironmentVariableIsSet("SNAP"));
++        const QString flatpakAppVar = QDir::homePath() + QLatin1String("/.var/app/");
++        if ((inSandbox && (storage.isReadOnly())) || storage.rootPath().startsWith(QLatin1String("/var/")) ||
++            storage.rootPath().startsWith(flatpakAppVar)) {
++            continue;
++        }
++
+         Disk disk;
+         disk.mount = storage.rootPath();
+         disk.name = storage.name();

--- a/org.kde.filelight.json
+++ b/org.kde.filelight.json
@@ -6,10 +6,10 @@
     "command": "filelight",
     "finish-args": [
         "--device=dri",
-        "--filesystem=host",
         "--share=ipc",
         "--socket=fallback-x11",
-        "--socket=wayland"
+        "--socket=wayland",
+        "--filesystem=home"
     ],
     "modules": [
         {
@@ -30,6 +30,10 @@
                 {
                     "type": "patch",
                     "path": "appdata.patch"
+                },
+                {
+                    "type": "patch",
+                    "path": "filter-out-sandbox-mounts.patch"
                 }
             ]
         }


### PR DESCRIPTION
This backports a patch in the 22.04 release that filters out a variety
of useless sandbox-related mounts to clean up the display. In addition,
it limits what the app can see to only the user's home directory, as
the display of the host's root filesystem is still exposed in a rather
messy way to Flatpak, and arguably this is more appropriate for a
sandboxed app context anyway.

This should be sufficient to bring the app out of beta and make it publicly available.

Next month when the 22.04 release is available, we can drop this patch.

![Filelight screenshot](https://user-images.githubusercontent.com/1097249/160904826-25cfdb1c-67ba-468a-adfa-b5eeee64d0bd.png)
