### PR TITLE
Allow access to ~/.var/app

### DIFF
--- a/org.kde.filelight.json
+++ b/org.kde.filelight.json
@@ -9,7 +9,8 @@
         "--share=ipc",
         "--socket=fallback-x11",
         "--socket=wayland",
-        "--filesystem=home"
+        "--filesystem=home",
+        "--filesystem=~/.var/app"
     ],
     "modules": [
         {


### PR DESCRIPTION
I think for this app to be useful, it needs to be able to access the flatpak ~/.var/app directory. This directory is excluded from the $home rule to prevent one flatpak app to access another flatpak app data. 

This is especially a problem on low storage devices like the steam deck. It has only 64 GB on the cheapest model. Steam deck users often install games inside the Bottles app and depend heavily on flatpak due to the immutability of the OS. When they run out of storage and install this app to troubleshoot, it does not find anything.

Here is a reddit thread that made me investigate this issue: https://old.reddit.com/r/SteamDeck/comments/z5qs0r/i_am_going_insane_ive_deleted_all_shader_cache/