### PR TITLE
Reduce the Flatpak size

### DIFF
--- a/org.kde.filelight.json
+++ b/org.kde.filelight.json
@@ -11,6 +11,10 @@
         "--socket=fallback-x11",
         "--socket=wayland"
     ],
+    "cleanup": [
+        "/share/doc",
+        "/share/qlogging-categories6"
+    ],
     "modules": [
         {
             "name": "filelight",


### PR DESCRIPTION
### Total

The installed size reduced from 1.4 MB to 573 kB.

### Drop /share/doc

KDE apps usually open an external website for help documentation.

This app uses the following page:

https://docs.kde.org/stable_kf6/en/filelight/filelight/index.html

### Drop /share/qlogging-categories

Many projects drop this folder:

https://github.com/search?q=org%3Aflathub+%2Fshare%2Fqlogging-categories&type=code